### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM adoptopenjdk/openjdk11:alpine@sha256:eb5fa8716ee201dc9ab2d9f016dbfe012dcd7376d1b66f1989e4ac8307333bde
+FROM adoptopenjdk/openjdk11:77acfacf04316729910564e20948aeff24fa6564ca0ba946d01c02c5eeba0f01
 
 CMD cat /etc/alpine-release 


### PR DESCRIPTION
`adoptopenjdk/openjdk11` changed recently. This pull request ensures you're using the latest version of the image and changes `adoptopenjdk/openjdk11` to the latest tag: `77acfacf04316729910564e20948aeff24fa6564ca0ba946d01c02c5eeba0f01`

New base image: `adoptopenjdk/openjdk11:77acfacf04316729910564e20948aeff24fa6564ca0ba946d01c02c5eeba0f01`